### PR TITLE
Health and data checks should use a url that can be filtered out by logging

### DIFF
--- a/web/sportparken/health/urls.py
+++ b/web/sportparken/health/urls.py
@@ -1,0 +1,8 @@
+from django.conf.urls import url
+
+from . import views
+
+urlpatterns = [
+    url(r'^health$', views.health),
+    url(r'^data$', views.check_data),
+]

--- a/web/sportparken/health/views.py
+++ b/web/sportparken/health/views.py
@@ -1,0 +1,47 @@
+# Python
+import logging
+# Packages
+from django.conf import settings
+from django.db import connection
+from django.http import HttpResponse
+
+# Project
+from sportparken.dataset.models import Sportpark
+
+log = logging.getLogger(__name__)
+
+
+def health(request):
+    # check database
+    try:
+        with connection.cursor() as cursor:
+            cursor.execute("SELECT 1")
+            assert cursor.fetchone()
+    except:
+        log.exception("Database connectivity failed")
+        return HttpResponse(
+            "Database connectivity failed",
+            content_type="text/plain", status=500)
+
+    # check debug
+    if settings.DEBUG:
+        log.exception("Debug mode not allowed in production")
+        return HttpResponse(
+            "Debug mode not allowed in production",
+            content_type="text/plain", status=500)
+
+    return HttpResponse(
+        "Health OK", content_type='text/plain', status=200)
+
+
+def check_data(request):
+    # check bag
+    try:
+        assert Sportpark.objects.count() > 30
+    except:
+        log.exception("No Sportparken data found")
+        return HttpResponse(
+            "No Sportparken data found",
+            content_type="text/plain", status=500)
+
+    return HttpResponse("Data OK", content_type='text/plain', status=200)

--- a/web/sportparken/settings.py
+++ b/web/sportparken/settings.py
@@ -22,8 +22,8 @@ from sportparken.settings_databases import LocationKey,\
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-
-insecure_secret = 'default-secret'
+# SECURITY WARNING: keep the secret key used in production secret!
+insecure_secret = 'insecure'
 SECRET_KEY = os.getenv('SECRET_KEY', insecure_secret)
 DEBUG = SECRET_KEY == insecure_secret
 
@@ -84,13 +84,6 @@ WSGI_APPLICATION = 'sportparken.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.10/ref/settings/#databases
-
-# DATABASES = {
-#     'default': {
-#         'ENGINE': 'django.db.backends.sqlite3',
-#         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-#     }
-# }
 
 DATABASE_OPTIONS = {
     LocationKey.docker: {

--- a/web/sportparken/settings.py
+++ b/web/sportparken/settings.py
@@ -25,6 +25,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # SECURITY WARNING: keep the secret key used in production secret!
 insecure_secret = 'insecure'
 SECRET_KEY = os.getenv('SECRET_KEY', insecure_secret)
+# If the SECRET_KEY != insecure_secret, DEBUG returns False
 DEBUG = SECRET_KEY == insecure_secret
 
 ALLOWED_HOSTS = ['*']

--- a/web/sportparken/urls.py
+++ b/web/sportparken/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     url(r'^admin/', admin.site.urls),
     url(r'^login/$', auth_views.login, name='login'),
     url(r'^logout/$', auth_views.logout, name='logout'),
+    url(r'^status/', include('sportparken.health.urls')),
     url(r'^api/', include('sportparken.api.urls', namespace='api')),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),
     url(r'^api-token-auth/', views.obtain_auth_token),


### PR DESCRIPTION
Health checks should use a url that can be filtered out by logging systems.  This allows us to separate the health checks from the real usage for statistical purposes. This PR uses the Django health and data checks setup reused from the bag repo.